### PR TITLE
Update README to reflect Node.js 22 and 24 directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bundle exec rake
 
 The above will run Serverspec and using the docker-api gem it will
 
-- Build a Docker image from the Docker file found in the top level directories (20 and 22)
+- Build a Docker image from the Docker file found in the top level directories (22 and 24)
 - Create a container of that image,
 - Run the tests found in `spec/` on the container
 - Delete the images and containers if the test was successful


### PR DESCRIPTION
## Summary

Updates the README documentation to match the current project structure after updating from Node.js 20 to Node.js 24.

## Changes

- Updated directory reference from **(20 and 22)** to **(22 and 24)**

## Why This Matters

The README was outdated after PR #65 renamed the `20/` directory to `24/`. This keeps the documentation accurate and prevents confusion for new users.

## What Was Changed

**Before:**
> Build a Docker image from the Docker file found in the top level directories (20 and 22)

**After:**
> Build a Docker image from the Docker file found in the top level directories (22 and 24)

This is a simple documentation update to keep the README in sync with the actual project structure.