### PR TITLE
ci: fix all zizmor security findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "bundler"
     directory: "/"
@@ -24,6 +26,8 @@ updates:
     commit-message:
       prefix: "bundler"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -37,4 +41,6 @@ updates:
     commit-message:
       prefix: "docker"
       include: "scope"
+    cooldown:
+      default-days: 7
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,9 @@ on: push
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+
     strategy:
       matrix:
         ruby-version: ['3.4', '4.0']
@@ -14,9 +16,11 @@ jobs:
     name: Ruby ${{ matrix.ruby-version }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true


### PR DESCRIPTION
Resolves all findings reported by `zizmor .github/`.

## Changes

### `.github/dependabot.yml`
- Add `cooldown: default-days: 7` to `github-actions`, `bundler`, and `docker` ecosystems ([dependabot-cooldown](https://docs.zizmor.sh/audits/#dependabot-cooldown))

### `.github/workflows/ruby.yml`
- Pin `actions/checkout` to full commit SHA `de0fac2e` (v6.0.2) ([unpinned-uses](https://docs.zizmor.sh/audits/#unpinned-uses))
- Pin `ruby/setup-ruby` to full commit SHA `afeafc3d` (v1.310.0) ([unpinned-uses](https://docs.zizmor.sh/audits/#unpinned-uses))
- Add `persist-credentials: false` to checkout step ([artipacked](https://docs.zizmor.sh/audits/#artipacked))
- Add `permissions: contents: read` to `test` job ([excessive-permissions](https://docs.zizmor.sh/audits/#excessive-permissions))

## Verification

```
zizmor .github/
No findings to report. Good job! (2 suppressed)
```