### PR TITLE
bundler(deps): bump specinfra from 2.94.1 to 2.95.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     multi_json (1.15.0)
     net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
-    net-ssh (7.3.0)
+    net-ssh (7.3.2)
     net-telnet (0.2.0)
     rake (13.4.2)
     rspec (3.13.2)
@@ -36,7 +36,7 @@ GEM
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    specinfra (2.94.1)
+    specinfra (2.95.0)
       base64
       net-scp
       net-ssh (>= 2.7)
@@ -52,3 +52,6 @@ DEPENDENCIES
   rake (~> 13.4)
   rspec (~> 3.13)
   serverspec (~> 2.43)
+
+BUNDLED WITH
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,3 @@ DEPENDENCIES
   rake (~> 13.4)
   rspec (~> 3.13)
   serverspec (~> 2.43)
-
-BUNDLED WITH
-   2.1.4


### PR DESCRIPTION
## Summary
- Bumps `specinfra` from 2.94.1 to 2.95.0
- 2.95.0 adds support for Kali Linux ([release notes](https://github.com/mizzy/specinfra/releases/tag/v2.95.0))

> **Note:** This update does not fix the `warning: Exception in finalizer` warnings seen in CI — that is a separate upstream issue being addressed in a companion PR.

## Test plan
- [ ] CI passes on both Ruby 3.4 and Ruby 4.0 jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)