### PR TITLE
fix: suppress specinfra Docker finalizer warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,15 @@ module Helpers
 
     puts "Deleting image..."
 
+    # Remove specinfra's Docker backend finalizer before we clean up containers.
+    # Without this, the finalizer fires at process exit and tries to stop/delete
+    # containers we've already removed here, producing "Exception in finalizer" warnings.
+    begin
+      ObjectSpace.undefine_finalizer(Specinfra.backend)
+    rescue => e
+      puts "Warning: Could not undefine specinfra finalizer: #{e.message}"
+    end
+
     # Stop and remove only containers created from this image
     begin
       Docker::Container.all(:all => true).each do |container|


### PR DESCRIPTION
## Summary
- Unregisters specinfra's Docker backend finalizer in `delete_image` before manually cleaning up containers
- Eliminates the `warning: Exception in finalizer` noise seen in CI on both Ruby 3.4 and Ruby 4.0 jobs

## Root cause
When `set :docker_image` is called, specinfra creates a container and registers an `ObjectSpace` finalizer to stop and delete it at process exit. Our `delete_image` helper already does that cleanup explicitly — so when the finalizer fires afterward, the containers are already gone and it raises an exception. Calling `ObjectSpace.undefine_finalizer` on the specinfra backend instance before our cleanup prevents the double-delete.

## Test plan
- [ ] CI passes without `warning: Exception in finalizer` lines in the "Run tests" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)