### PR TITLE
chore: update dependabot schedule to daily for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:30"
       timezone: "America/Toronto"
     pull-request-branch-name:
@@ -32,8 +31,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:55"
       timezone: "America/Toronto"
     pull-request-branch-name:
@@ -47,8 +45,7 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "10:00"
       timezone: "America/Toronto"
     pull-request-branch-name:


### PR DESCRIPTION
## Summary

- Updated `github-actions`, `docker`, and `pre-commit` ecosystems from `weekly` (Monday) to `daily`
- `bundler` was already set to daily and is unchanged

## Test plan

- [ ] Verify dependabot.yml is valid YAML
- [ ] Confirm Dependabot picks up the new schedule after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)