### PR TITLE
ci: fix ruby/setup-ruby cache poisoning and stale version comment

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,10 +20,12 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.310.0 # zizmor: ignore[cache-poisoning]
+      uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
+        bundler-cache: false
+    - name: Install gems
+      run: bundle install
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       with:


### PR DESCRIPTION
## Summary
- Disable `bundler-cache` on the `ruby/setup-ruby` step and add an explicit `bundle install` step, resolving a zizmor `cache-poisoning` finding (bundler cache combined with `docker/build-push-action` publishing runtime artifacts).
- Correct the trailing version comment on `ruby/setup-ruby` from `v1.310.0` to `v1.315.0` to match the actually pinned commit SHA.

## Verification
- `zizmor .github/workflows/ruby.yml` reports no findings.
- `pre-commit run --all-files` passes (actionlint, zizmor, rubocop, etc.).